### PR TITLE
Allow passing customer metadata into widget

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,16 @@ Paste the code below between your `<head>` and `</head>` tags:
       title: 'Welcome to Papercups!',
       subtitle: 'Ask us anything in the chat window below 😊',
       primaryColor: '#13c2c2',
+      // Optionally pass in a default greeting
+      greeting: 'Hi there! How can I help you?',
+      // Optionally pass in metadata to identify the customer
+      customer: {
+        name: 'Test User',
+        email: 'test@test.com',
+        external_id: '123',
+      },
+      // Optionally specify the base URL
+      baseUrl: 'https://app.papercups.io',
     },
   };
 </script>
@@ -65,6 +75,16 @@ const ExamplePage = () => {
         subtitle='Ask us anything in the chat window below 😊'
         primaryColor='#13c2c2'
         accountId='xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxx'
+        // Optionally pass in a default greeting
+        greeting='Hi there! How can I help you?'
+        // Optionally pass in metadata to identify the customer
+        customer={{
+          name: 'Test User',
+          email: 'test@test.com',
+          external_id: '123',
+        }}
+        // Optionally specify the base URL
+        baseUrl='https://app.papercups.io'
       />
     </>
   );

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -45,6 +45,11 @@ const App = ({disco}: Props) => {
         primaryColor={primaryColor}
         accountId='eb504736-0f20-4978-98ff-1a82ae60b266'
         greeting='Hi there! How can I help you?'
+        customer={{
+          name: 'Test User',
+          email: 'test@test.com',
+          external_id: '123',
+        }}
         // TODO: default to point to production once that's working
         baseUrl='http://localhost:4000'
       />

--- a/example/src/index.css
+++ b/example/src/index.css
@@ -1,3 +1,4 @@
+html,
 body {
   margin: 0;
   padding: 0;
@@ -6,6 +7,9 @@ body {
     sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+
+  height: 100%;
+  width: 100%;
 }
 
 code {

--- a/src/api.ts
+++ b/src/api.ts
@@ -2,19 +2,43 @@ import request from 'superagent';
 import {DEFAULT_BASE_URL} from './config';
 import {now} from './utils';
 
+export type CustomerMetadata = {
+  name: string;
+  email: string;
+  external_id: string;
+  // TODO: include browser info
+};
+
+const EMPTY_METADATA = {} as CustomerMetadata;
+
 export const createNewCustomer = async (
   accountId: string,
+  metadata: CustomerMetadata = EMPTY_METADATA,
   baseUrl = DEFAULT_BASE_URL
 ) => {
   return request
     .post(`${baseUrl}/api/customers`)
     .send({
       customer: {
+        ...metadata,
         account_id: accountId,
         first_seen: now(),
         last_seen: now(),
       },
-    }) // TODO: send over some metadata?
+    })
+    .then((res) => res.body.data);
+};
+
+export const updateCustomerMetadata = async (
+  customerId: string,
+  metadata: CustomerMetadata = EMPTY_METADATA,
+  baseUrl = DEFAULT_BASE_URL
+) => {
+  return request
+    .put(`${baseUrl}/api/customers/${customerId}/metadata`)
+    .send({
+      metadata,
+    })
     .then((res) => res.body.data);
 };
 

--- a/src/components/ChatWindow.tsx
+++ b/src/components/ChatWindow.tsx
@@ -101,18 +101,10 @@ class ChatWindow extends React.Component<Props, State> {
 
       const [latest] = conversations;
       const {id: conversationId, messages = []} = latest;
-      const formattedMessages = messages
-        .map((msg: Message) => {
-          return {
-            ...msg,
-            // Deprecate
-            sender: msg.customer_id ? 'customer' : 'agent',
-          };
-        })
-        .sort(
-          (a: Message, b: Message) =>
-            +new Date(a.created_at) - +new Date(b.created_at)
-        );
+      const formattedMessages = messages.sort(
+        (a: Message, b: Message) =>
+          +new Date(a.created_at) - +new Date(b.created_at)
+      );
 
       this.setState({
         conversationId,
@@ -237,7 +229,6 @@ class ChatWindow extends React.Component<Props, State> {
     this.channel.push('shout', {
       body: message,
       customer_id: this.state.customerId,
-      sender: 'customer', // TODO: remove?
     });
 
     this.setState({message: ''});

--- a/src/components/ChatWindow.tsx
+++ b/src/components/ChatWindow.tsx
@@ -15,6 +15,7 @@ type Props = {
   subtitle?: string;
   baseUrl?: string;
   greeting?: string;
+  customer?: API.CustomerMetadata;
 };
 
 type State = {
@@ -68,7 +69,7 @@ class ChatWindow extends React.Component<Props, State> {
     ];
   };
 
-  fetchLatestConversation = (customerId: string) => {
+  fetchLatestConversation = async (customerId: string) => {
     if (!customerId) {
       // If there's no customerId, we haven't seen this customer before,
       // so do nothing until they try to create a new message
@@ -77,54 +78,83 @@ class ChatWindow extends React.Component<Props, State> {
       return;
     }
 
-    const {accountId, baseUrl} = this.props;
+    const {accountId, baseUrl, customer: metadata} = this.props;
 
     console.log('Fetching conversations for customer:', customerId);
 
-    return API.fetchCustomerConversations(customerId, accountId, baseUrl)
-      .then((conversations) => {
-        console.log('Found existing conversations:', conversations);
+    try {
+      const conversations = await API.fetchCustomerConversations(
+        customerId,
+        accountId,
+        baseUrl
+      );
 
-        if (!conversations || !conversations.length) {
-          // If there are no conversations yet, wait until the customer creates
-          // a new message to create the new conversation
-          this.setState({messages: [...this.getDefaultGreeting()]});
+      console.log('Found existing conversations:', conversations);
 
-          return;
-        }
+      if (!conversations || !conversations.length) {
+        // If there are no conversations yet, wait until the customer creates
+        // a new message to create the new conversation
+        this.setState({messages: [...this.getDefaultGreeting()]});
 
-        const [latest] = conversations;
-        const {id: conversationId, messages = []} = latest;
-        const formattedMessages = messages
-          .map((msg: Message) => {
-            return {
-              ...msg,
-              // Deprecate
-              sender: msg.customer_id ? 'customer' : 'agent',
-            };
-          })
-          .sort(
-            (a: Message, b: Message) =>
-              +new Date(a.created_at) - +new Date(b.created_at)
-          );
+        return;
+      }
 
-        this.setState({
-          conversationId,
-          messages: [...this.getDefaultGreeting(), ...formattedMessages],
-        });
+      const [latest] = conversations;
+      const {id: conversationId, messages = []} = latest;
+      const formattedMessages = messages
+        .map((msg: Message) => {
+          return {
+            ...msg,
+            // Deprecate
+            sender: msg.customer_id ? 'customer' : 'agent',
+          };
+        })
+        .sort(
+          (a: Message, b: Message) =>
+            +new Date(a.created_at) - +new Date(b.created_at)
+        );
 
-        return this.joinConversationChannel(conversationId);
-      })
-      .catch((err) => console.log('Error fetching conversations!', err));
+      this.setState({
+        conversationId,
+        messages: [...this.getDefaultGreeting(), ...formattedMessages],
+      });
+
+      this.joinConversationChannel(conversationId);
+
+      await this.updateExistingCustomer(customerId, metadata);
+    } catch (err) {
+      console.log('Error fetching conversations!', err);
+    }
   };
 
   createNewCustomerId = async (accountId: string) => {
-    const {baseUrl} = this.props;
-    const {id: customerId} = await API.createNewCustomer(accountId, baseUrl);
+    const {baseUrl, customer: metadata} = this.props;
+    const {id: customerId} = await API.createNewCustomer(
+      accountId,
+      metadata,
+      baseUrl
+    );
 
     setCustomerId(customerId);
 
     return customerId;
+  };
+
+  updateExistingCustomer = async (
+    customerId: string,
+    metadata?: API.CustomerMetadata
+  ) => {
+    if (!metadata) {
+      return;
+    }
+
+    try {
+      const {baseUrl} = this.props;
+
+      await API.updateCustomerMetadata(customerId, metadata, baseUrl);
+    } catch (err) {
+      console.log('Error updating customer metadata!', err);
+    }
   };
 
   initializeNewConversation = async () => {

--- a/src/components/EmbeddableWidget.tsx
+++ b/src/components/EmbeddableWidget.tsx
@@ -3,6 +3,7 @@ import {motion} from 'framer-motion';
 import {ThemeProvider} from 'theme-ui';
 import ChatWindow from './ChatWindow';
 import WidgetToggle from './WidgetToggle';
+import {CustomerMetadata} from '../api';
 import getThemeConfig from '../theme';
 
 type Props = {
@@ -12,6 +13,7 @@ type Props = {
   accountId: string;
   baseUrl?: string;
   greeting?: string;
+  customer?: CustomerMetadata;
   defaultIsOpen?: boolean;
 };
 
@@ -22,6 +24,7 @@ const EmbeddableWidget = ({
   primaryColor,
   baseUrl,
   greeting,
+  customer,
   defaultIsOpen = false,
 }: Props) => {
   const [isOpen, setIsOpen] = React.useState(defaultIsOpen);
@@ -57,6 +60,7 @@ const EmbeddableWidget = ({
             subtitle={subtitle}
             accountId={accountId}
             greeting={greeting}
+            customer={customer}
             baseUrl={baseUrl}
           />
         </motion.div>


### PR DESCRIPTION
Adds `customer` prop to allow passing in metadata (limited to `name`, `email`, `external_id` for now)