### PR TITLE
Add class names to components as short-term fix to css customization

### DIFF
--- a/src/components/ChatWindow.tsx
+++ b/src/components/ChatWindow.tsx
@@ -255,7 +255,11 @@ class ChatWindow extends React.Component<Props, State> {
         }}
       >
         <Box py={3} px={4} sx={{bg: 'primary'}}>
-          <Heading as='h2' sx={{color: 'background', my: 1}}>
+          <Heading
+            as='h2'
+            className='Papercups-heading'
+            sx={{color: 'background', my: 1}}
+          >
             {title}
           </Heading>
           <Text sx={{color: 'offset'}}>{subtitle}</Text>

--- a/src/components/EmbeddableWidget.tsx
+++ b/src/components/EmbeddableWidget.tsx
@@ -39,6 +39,7 @@ const EmbeddableWidget = ({
       {/* TODO: use emotion or styled to handle this? */}
       {isOpen && (
         <motion.div
+          className='Papercups-chatWindowContainer'
           initial={{opacity: 0, y: 4}}
           animate={{opacity: 1, y: 0}}
           transition={{duration: 0.2, ease: 'easeIn'}}
@@ -57,13 +58,11 @@ const EmbeddableWidget = ({
         </motion.div>
       )}
       <motion.div
+        className='Papercups-toggleButtonContainer'
         initial={false}
         animate={isOpen ? 'open' : 'closed'}
-        style={{
-          position: 'fixed',
-          zIndex: 2147483003,
-          bottom: '20px',
-          right: '20px',
+        sx={{
+          variant: 'styles.WidgetToggleContainer',
         }}
       >
         <WidgetToggle toggle={handleToggleOpen} />

--- a/src/components/WidgetToggle.tsx
+++ b/src/components/WidgetToggle.tsx
@@ -23,6 +23,7 @@ export const WidgetToggle = ({toggle}: {toggle: () => void}) => {
       }}
     >
       <Button
+        className='Papercups-toggleButton'
         p={0}
         sx={{
           bg: 'primary',

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -198,6 +198,12 @@ export const getThemeConfig = (settings: ThemeSettings) => {
         borderRadius: 8,
         overflow: 'hidden',
       },
+      WidgetToggleContainer: {
+        position: 'fixed',
+        zIndex: 2147483003,
+        bottom: '20px',
+        right: '20px',
+      },
       WidgetToggle: {
         outline: 'none',
         border: 'none',


### PR DESCRIPTION
for example, if you wanted to move the widget to the left side of the page, you could do something like
```css
.Papercups-chatWindowContainer {
  left: 20px !important;
  right: auto !important;
}

.Papercups-toggleButtonContainer {
  left: 20px !important;
  right: auto !important;
}

/* if you also wanted to adjust the heading size */
.Papercups-heading {
  font-size: 20px;
}
```

<img width="1239" alt="Screen Shot 2020-08-05 at 3 11 52 PM" src="https://user-images.githubusercontent.com/5264279/89454055-23f5cc00-d72e-11ea-8779-2642de37de84.png">
