### PR TITLE
Allow iframe url override

### DIFF
--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -51,8 +51,10 @@ const App = ({disco}: Props) => {
           email: 'test@test.com',
           external_id: '123',
         }}
-        // TODO: default to point to production once that's working
+        // NB: we override these values during development -- note that the
+        // API runs on port 4000 by default, and the iframe on 8080
         baseUrl='http://localhost:4000'
+        iframeUrlOverride='http://localhost:8080'
         requireEmailUpfront
         defaultIsOpen
       />

--- a/example/src/index.tsx
+++ b/example/src/index.tsx
@@ -4,4 +4,4 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import App from './App';
 
-ReactDOM.render(<App disco />, document.getElementById('root'));
+ReactDOM.render(<App />, document.getElementById('root'));

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@papercups-io/chat-widget",
-  "version": "1.0.25-beta.0",
+  "version": "1.0.25-beta.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@papercups-io/chat-widget",
-  "version": "1.0.25-beta.0",
+  "version": "1.0.25-beta.1",
   "description": "Papercups chat widget",
   "author": "reichert621",
   "license": "MIT",


### PR DESCRIPTION
Adds the `iframeUrlOverride` to the React component so users can specify their own chat window iframe url if they choose to.

(see https://github.com/papercups-io/chat-widget/issues/24)