### PR TITLE
[v1.1.0] Export `ChatWindow` as separate component

### DIFF
--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -1,6 +1,11 @@
 import React from 'react';
 
-import ChatWidget, {ChatWindow} from '@papercups-io/chat-widget';
+import ChatWidget, {
+  ChatWindow,
+  toggle,
+  open,
+  close,
+} from '@papercups-io/chat-widget';
 
 type Props = {disco?: boolean; displayChatWindow?: boolean};
 
@@ -119,6 +124,10 @@ const App = ({disco, displayChatWindow}: Props) => {
           onMessageSent={(message) => console.log('Message sent!', message)}
         />
       )}
+
+      <button onClick={open}>Open</button>
+      <button onClick={close}>Close</button>
+      <button onClick={toggle}>Toggle</button>
     </>
   );
 };

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -1,11 +1,6 @@
 import React from 'react';
 
-import ChatWidget, {
-  ChatWindow,
-  toggle,
-  open,
-  close,
-} from '@papercups-io/chat-widget';
+import ChatWidget, {ChatWindow, Papercups} from '@papercups-io/chat-widget';
 
 type Props = {disco?: boolean; displayChatWindow?: boolean};
 
@@ -125,9 +120,9 @@ const App = ({disco, displayChatWindow}: Props) => {
         />
       )}
 
-      <button onClick={open}>Open</button>
-      <button onClick={close}>Close</button>
-      <button onClick={toggle}>Toggle</button>
+      <button onClick={Papercups.open}>Open</button>
+      <button onClick={Papercups.close}>Close</button>
+      <button onClick={Papercups.toggle}>Toggle</button>
     </>
   );
 };

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import {ChatWidget, ChatWindow} from '@papercups-io/chat-widget';
+import ChatWidget, {ChatWindow} from '@papercups-io/chat-widget';
 
 type Props = {disco?: boolean; displayChatWindow?: boolean};
 

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -70,6 +70,7 @@ const App = ({disco, displayChatWindow}: Props) => {
             baseUrl='http://localhost:4000'
             iframeUrlOverride='http://localhost:8080'
             requireEmailUpfront
+            showAgentAvailability
             onChatClosed={() => console.log('Chat closed!')}
             onChatOpened={() => console.log('Chat opened!')}
             onMessageReceived={(message) =>
@@ -108,6 +109,7 @@ const App = ({disco, displayChatWindow}: Props) => {
           baseUrl='http://localhost:4000'
           iframeUrlOverride='http://localhost:8080'
           requireEmailUpfront
+          showAgentAvailability
           defaultIsOpen={false}
           onChatClosed={() => console.log('Chat closed!')}
           onChatOpened={() => console.log('Chat opened!')}

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -1,10 +1,10 @@
 import React from 'react';
 
-import ChatWidget from '@papercups-io/chat-widget';
+import {ChatWidget, ChatWindow} from '@papercups-io/chat-widget';
 
-type Props = {disco?: boolean};
+type Props = {disco?: boolean; displayChatWindow?: boolean};
 
-const App = ({disco}: Props) => {
+const App = ({disco, displayChatWindow}: Props) => {
   const colors = [
     '#1890ff',
     '#f5222d',
@@ -34,46 +34,89 @@ const App = ({disco}: Props) => {
 
   return (
     <>
-      {/*
-        Put <ChatWidget /> at the bottom of whatever pages you would
-        like to render the widget on, or in your root/router component
-        if you would like it to render on every page
-      */}
-      <ChatWidget
-        title='Welcome to Papercups!'
-        subtitle='Ask us anything in the chat window 😊'
-        primaryColor={primaryColor}
-        accountId='eb504736-0f20-4978-98ff-1a82ae60b266'
-        greeting='Hi there! How can I help you?'
-        newMessagePlaceholder='Start typing...'
-        agentAvailableText='Agents are online!'
-        agentUnavailableText='Agents are not available at the moment.'
-        showAgentAvailability
-        customer={{
-          name: 'Test User',
-          email: 'test@test.com',
-          external_id: '123',
-          // Ad hoc metadata
-          metadata: {
-            plan: 'starter',
-            registered_at: '2020-09-01',
-            age: 25,
-            valid: true,
-          },
-        }}
-        // NB: we override these values during development -- note that the
-        // API runs on port 4000 by default, and the iframe on 8080
-        baseUrl='http://localhost:4000'
-        iframeUrlOverride='http://localhost:8080'
-        requireEmailUpfront
-        defaultIsOpen={false}
-        onChatClosed={() => console.log('Chat closed!')}
-        onChatOpened={() => console.log('Chat opened!')}
-        onMessageReceived={(message) =>
-          console.log('Message received!', message)
-        }
-        onMessageSent={(message) => console.log('Message sent!', message)}
-      />
+      {displayChatWindow ? (
+        <div
+          style={{
+            padding: 32,
+            height: 480,
+            width: '50%',
+            minWidth: 320,
+            maxWidth: 400,
+          }}
+        >
+          <ChatWindow
+            title='Welcome to Papercups!'
+            subtitle='Ask us anything in the chat window 😊'
+            primaryColor={primaryColor}
+            accountId='eb504736-0f20-4978-98ff-1a82ae60b266'
+            greeting='Hi there! How can I help you?'
+            newMessagePlaceholder='Start typing...'
+            agentAvailableText='Agents are online!'
+            agentUnavailableText='Agents are not available at the moment.'
+            customer={{
+              name: 'Test User',
+              email: 'test@test.com',
+              external_id: '123',
+              // Ad hoc metadata
+              metadata: {
+                plan: 'starter',
+                registered_at: '2020-09-01',
+                age: 25,
+                valid: true,
+              },
+            }}
+            // NB: we override these values during development -- note that the
+            // API runs on port 4000 by default, and the iframe on 8080
+            baseUrl='http://localhost:4000'
+            iframeUrlOverride='http://localhost:8080'
+            requireEmailUpfront
+            onChatClosed={() => console.log('Chat closed!')}
+            onChatOpened={() => console.log('Chat opened!')}
+            onMessageReceived={(message) =>
+              console.log('Message received!', message)
+            }
+            onMessageSent={(message) => console.log('Message sent!', message)}
+          />
+        </div>
+      ) : (
+        // Put <ChatWidget /> at the bottom of whatever pages you would
+        // like to render the widget on, or in your root/router component
+        // if you would like it to render on every page
+        <ChatWidget
+          title='Welcome to Papercups!'
+          subtitle='Ask us anything in the chat window 😊'
+          primaryColor={primaryColor}
+          accountId='eb504736-0f20-4978-98ff-1a82ae60b266'
+          greeting='Hi there! How can I help you?'
+          newMessagePlaceholder='Start typing...'
+          agentAvailableText='Agents are online!'
+          agentUnavailableText='Agents are not available at the moment.'
+          customer={{
+            name: 'Test User',
+            email: 'test@test.com',
+            external_id: '123',
+            // Ad hoc metadata
+            metadata: {
+              plan: 'starter',
+              registered_at: '2020-09-01',
+              age: 25,
+              valid: true,
+            },
+          }}
+          // NB: we override these values during development -- note that the
+          // API runs on port 4000 by default, and the iframe on 8080
+          baseUrl='http://localhost:4000'
+          iframeUrlOverride='http://localhost:8080'
+          requireEmailUpfront
+          defaultIsOpen={false}
+          onChatClosed={() => console.log('Chat closed!')}
+          onChatOpened={() => console.log('Chat opened!')}
+          onMessageReceived={(message) =>
+            console.log('Message received!', message)
+          }
+          onMessageSent={(message) => console.log('Message sent!', message)}
+        />
+      )}
     </>
   );
 };

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -71,6 +71,7 @@ const App = ({disco, displayChatWindow}: Props) => {
             iframeUrlOverride='http://localhost:8080'
             requireEmailUpfront
             showAgentAvailability
+            onChatLoaded={() => console.log('Chat loaded!')}
             onChatClosed={() => console.log('Chat closed!')}
             onChatOpened={() => console.log('Chat opened!')}
             onMessageReceived={(message) =>
@@ -111,6 +112,7 @@ const App = ({disco, displayChatWindow}: Props) => {
           requireEmailUpfront
           showAgentAvailability
           defaultIsOpen={false}
+          onChatLoaded={() => console.log('Chat loaded!')}
           onChatClosed={() => console.log('Chat closed!')}
           onChatOpened={() => console.log('Chat opened!')}
           onMessageReceived={(message) =>

--- a/example/src/index.css
+++ b/example/src/index.css
@@ -16,3 +16,8 @@ code {
   font-family: source-code-pro, Menlo, Monaco, Consolas, 'Courier New',
     monospace;
 }
+
+.Papercups-chatWindowContainer {
+  border-radius: 4px;
+  box-shadow: rgba(0, 0, 0, 0.16) 0px 5px 24px;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@papercups-io/chat-widget",
-  "version": "1.1.0-beta.0",
+  "version": "1.1.0-beta.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@papercups-io/chat-widget",
-  "version": "1.0.34",
+  "version": "1.1.0-beta.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@papercups-io/chat-widget",
-  "version": "1.1.0-beta.1",
+  "version": "1.1.0-beta.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@papercups-io/chat-widget",
-  "version": "1.1.0-beta.2",
+  "version": "1.1.0-beta.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@papercups-io/chat-widget",
-  "version": "1.1.0-beta.4",
+  "version": "1.1.0-beta.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@papercups-io/chat-widget",
-  "version": "1.1.0-beta.3",
+  "version": "1.1.0-beta.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@papercups-io/chat-widget",
-  "version": "1.1.0-beta.2",
+  "version": "1.1.0-beta.3",
   "description": "Papercups chat widget",
   "author": "reichert621",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@papercups-io/chat-widget",
-  "version": "1.0.34",
+  "version": "1.1.0-beta.0",
   "description": "Papercups chat widget",
   "author": "reichert621",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@papercups-io/chat-widget",
-  "version": "1.1.0-beta.1",
+  "version": "1.1.0-beta.2",
   "description": "Papercups chat widget",
   "author": "reichert621",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@papercups-io/chat-widget",
-  "version": "1.1.0-beta.0",
+  "version": "1.1.0-beta.1",
   "description": "Papercups chat widget",
   "author": "reichert621",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@papercups-io/chat-widget",
-  "version": "1.1.0-beta.3",
+  "version": "1.1.0-beta.4",
   "description": "Papercups chat widget",
   "author": "reichert621",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@papercups-io/chat-widget",
-  "version": "1.1.0-beta.4",
+  "version": "1.1.0-beta.5",
   "description": "Papercups chat widget",
   "author": "reichert621",
   "license": "MIT",

--- a/src/api.ts
+++ b/src/api.ts
@@ -31,6 +31,7 @@ export type CustomerMetadata = {
 
 export type Account = {
   company_name?: string;
+  subscription_plan?: string;
 };
 
 export type WidgetSettings = {

--- a/src/components/ChatWidget.tsx
+++ b/src/components/ChatWidget.tsx
@@ -31,7 +31,7 @@ type Props = {
 
 const ChatWidget = (props: Props) => {
   return (
-    <ChatWidgetContainer {...props}>
+    <ChatWidgetContainer {...props} canToggle>
       {(config) => {
         const {
           sandbox,

--- a/src/components/ChatWidget.tsx
+++ b/src/components/ChatWidget.tsx
@@ -4,29 +4,10 @@ import React from 'react';
 import {motion} from 'framer-motion';
 import {jsx} from 'theme-ui';
 import WidgetToggle from './WidgetToggle';
-import ChatWidgetContainer from './ChatWidgetContainer';
-import {CustomerMetadata, Message} from '../api';
+import ChatWidgetContainer, {SharedProps} from './ChatWidgetContainer';
 
-type Props = {
-  title?: string;
-  subtitle?: string;
-  primaryColor?: string;
-  accountId: string;
-  baseUrl?: string;
-  greeting?: string;
-  customer?: CustomerMetadata | null;
-  newMessagePlaceholder?: string;
-  agentAvailableText?: string;
-  agentUnavailableText?: string;
-  showAgentAvailability?: boolean;
-  iframeUrlOverride?: string;
-  requireEmailUpfront?: boolean;
+type Props = SharedProps & {
   defaultIsOpen?: boolean;
-  customIconUrl?: string;
-  onChatOpened?: () => void;
-  onChatClosed?: () => void;
-  onMessageSent?: (message: Message) => void;
-  onMessageReceived?: (message: Message) => void;
 };
 
 const ChatWidget = (props: Props) => {

--- a/src/components/ChatWidgetContainer.tsx
+++ b/src/components/ChatWidgetContainer.tsx
@@ -71,6 +71,7 @@ type Props = {
   requireEmailUpfront?: boolean;
   defaultIsOpen?: boolean;
   customIconUrl?: string;
+  canToggle?: boolean;
   onChatOpened?: () => void;
   onChatClosed?: () => void;
   onMessageSent?: (message: Message) => void;
@@ -362,7 +363,7 @@ class ChatWidgetContainer extends React.Component<Props, State> {
   handleChatLoaded = () => {
     this.setState({isLoaded: true});
 
-    if (this.props.defaultIsOpen) {
+    if (this.props.defaultIsOpen || !this.props.canToggle) {
       this.setState({isOpen: true}, () => this.emitToggleEvent(true));
     }
 
@@ -413,10 +414,18 @@ class ChatWidgetContainer extends React.Component<Props, State> {
   };
 
   handleOpenWidget = () => {
+    if (!this.props.canToggle || this.state.isOpen) {
+      return;
+    }
+
     this.setState({isOpen: true}, () => this.emitToggleEvent(true));
   };
 
   handleCloseWidget = () => {
+    if (!this.props.canToggle || !this.state.isOpen) {
+      return;
+    }
+
     this.setState({isOpen: false}, () => this.emitToggleEvent(false));
   };
 
@@ -425,7 +434,7 @@ class ChatWidgetContainer extends React.Component<Props, State> {
     const isOpen = !wasOpen;
 
     // Prevent opening the widget until everything has loaded
-    if (!isLoaded) {
+    if (!isLoaded || !this.props.canToggle) {
       return;
     }
 

--- a/src/components/ChatWidgetContainer.tsx
+++ b/src/components/ChatWidgetContainer.tsx
@@ -54,8 +54,7 @@ const setupCustomEventHandlers = (
   }
 };
 
-// TODO: DRY up props with ChatWidget component
-type Props = {
+export type SharedProps = {
   title?: string;
   subtitle?: string;
   primaryColor?: string;
@@ -69,13 +68,17 @@ type Props = {
   showAgentAvailability?: boolean;
   iframeUrlOverride?: string;
   requireEmailUpfront?: boolean;
-  defaultIsOpen?: boolean;
   customIconUrl?: string;
-  canToggle?: boolean;
+  onChatLoaded?: () => void;
   onChatOpened?: () => void;
   onChatClosed?: () => void;
   onMessageSent?: (message: Message) => void;
   onMessageReceived?: (message: Message) => void;
+};
+
+type Props = SharedProps & {
+  defaultIsOpen?: boolean;
+  canToggle?: boolean;
   children: (data: any) => any;
 };
 
@@ -362,12 +365,13 @@ class ChatWidgetContainer extends React.Component<Props, State> {
 
   handleChatLoaded = () => {
     this.setState({isLoaded: true});
+    const {defaultIsOpen, canToggle, onChatLoaded = noop} = this.props;
 
-    if (this.props.defaultIsOpen || !this.props.canToggle) {
+    if (defaultIsOpen || !canToggle) {
       this.setState({isOpen: true}, () => this.emitToggleEvent(true));
     }
 
-    return this.send('papercups:ping'); // Just testing
+    return onChatLoaded && onChatLoaded();
   };
 
   formatCustomerMetadata = () => {

--- a/src/components/ChatWidgetContainer.tsx
+++ b/src/components/ChatWidgetContainer.tsx
@@ -162,6 +162,7 @@ class ChatWidgetContainer extends React.Component<Props, State> {
       requireEmailUpfront: requireEmailUpfront ? 1 : 0,
       showAgentAvailability: showAgentAvailability ? 1 : 0,
       customerId: this.storage.getCustomerId(),
+      subscriptionPlan: settings?.account?.subscription_plan,
       metadata: JSON.stringify(metadata),
     };
 
@@ -367,13 +368,20 @@ class ChatWidgetContainer extends React.Component<Props, State> {
 
   handleChatLoaded = () => {
     this.setState({isLoaded: true});
+
+    const {config = {} as WidgetConfig} = this.state;
+    const {subscriptionPlan = null} = config;
     const {defaultIsOpen, canToggle, onChatLoaded = noop} = this.props;
+
+    if (onChatLoaded && typeof onChatLoaded === 'function') {
+      onChatLoaded();
+    }
 
     if (defaultIsOpen || !canToggle) {
       this.setState({isOpen: true}, () => this.emitToggleEvent(true));
     }
 
-    return onChatLoaded && onChatLoaded();
+    this.send('papercups:plan', {plan: subscriptionPlan});
   };
 
   formatCustomerMetadata = () => {

--- a/src/components/ChatWidgetContainer.tsx
+++ b/src/components/ChatWidgetContainer.tsx
@@ -118,6 +118,8 @@ class ChatWidgetContainer extends React.Component<Props, State> {
   }
 
   async componentDidMount() {
+    // TODO: use `subscription_plan` from settings.account to determine
+    // whether to display the Papercups branding or not in the chat window
     const settings = await this.fetchWidgetSettings();
     const {
       accountId,

--- a/src/components/ChatWindow.tsx
+++ b/src/components/ChatWindow.tsx
@@ -26,6 +26,8 @@ type Props = {
 };
 
 const ChatWindow = (props: Props) => {
+  // TODO: add a prop to `ChatWidgetContainer` to indicate when component is not
+  // the widget (e.g. it is never toggled open/closed, no need to show notifications)
   return (
     <ChatWidgetContainer {...props} defaultIsOpen>
       {(config) => {

--- a/src/components/ChatWindow.tsx
+++ b/src/components/ChatWindow.tsx
@@ -1,6 +1,7 @@
 /** @jsx jsx */
 
 import {jsx} from 'theme-ui';
+import {motion} from 'framer-motion';
 import ChatWidgetContainer from './ChatWidgetContainer';
 import {CustomerMetadata, Message} from '../api';
 
@@ -31,22 +32,30 @@ const ChatWindow = (props: Props) => {
   return (
     <ChatWidgetContainer {...props} defaultIsOpen>
       {(config) => {
-        const {sandbox, iframeUrl, query, setIframeRef} = config;
+        const {sandbox, isLoaded, iframeUrl, query, setIframeRef} = config;
 
         return (
-          <iframe
+          <motion.iframe
             ref={setIframeRef}
             className='Papercups-chatWindowContainer'
             sandbox={sandbox}
+            animate={isLoaded ? 'open' : 'closed'}
+            initial='closed'
+            variants={{
+              closed: {opacity: 0},
+              open: {opacity: 1},
+            }}
+            transition={{duration: 0.2, ease: 'easeIn'}}
             src={`${iframeUrl}?${query}`}
             sx={{
+              opacity: isLoaded ? 1 : 0,
               border: 'none',
               bg: 'background',
               variant: 'styles.ChatWindowContainer',
             }}
           >
             Loading...
-          </iframe>
+          </motion.iframe>
         );
       }}
     </ChatWidgetContainer>

--- a/src/components/ChatWindow.tsx
+++ b/src/components/ChatWindow.tsx
@@ -1,0 +1,54 @@
+/** @jsx jsx */
+
+import {jsx} from 'theme-ui';
+import ChatWidgetContainer from './ChatWidgetContainer';
+import {CustomerMetadata, Message} from '../api';
+
+type Props = {
+  title?: string;
+  subtitle?: string;
+  primaryColor?: string;
+  accountId: string;
+  baseUrl?: string;
+  greeting?: string;
+  customer?: CustomerMetadata | null;
+  newMessagePlaceholder?: string;
+  agentAvailableText?: string;
+  agentUnavailableText?: string;
+  showAgentAvailability?: boolean;
+  iframeUrlOverride?: string;
+  requireEmailUpfront?: boolean;
+  customIconUrl?: string;
+  onChatOpened?: () => void;
+  onChatClosed?: () => void;
+  onMessageSent?: (message: Message) => void;
+  onMessageReceived?: (message: Message) => void;
+};
+
+const ChatWindow = (props: Props) => {
+  return (
+    <ChatWidgetContainer {...props} defaultIsOpen>
+      {(config) => {
+        const {sandbox, iframeUrl, query, setIframeRef} = config;
+
+        return (
+          <iframe
+            ref={setIframeRef}
+            className='Papercups-chatWindowContainer'
+            sandbox={sandbox}
+            src={`${iframeUrl}?${query}`}
+            sx={{
+              border: 'none',
+              bg: 'background',
+              variant: 'styles.ChatWindowContainer',
+            }}
+          >
+            Loading...
+          </iframe>
+        );
+      }}
+    </ChatWidgetContainer>
+  );
+};
+
+export default ChatWindow;

--- a/src/components/ChatWindow.tsx
+++ b/src/components/ChatWindow.tsx
@@ -30,7 +30,7 @@ const ChatWindow = (props: Props) => {
   // TODO: add a prop to `ChatWidgetContainer` to indicate when component is not
   // the widget (e.g. it is never toggled open/closed, no need to show notifications)
   return (
-    <ChatWidgetContainer {...props} defaultIsOpen>
+    <ChatWidgetContainer {...props} canToggle={false}>
       {(config) => {
         const {sandbox, isLoaded, iframeUrl, query, setIframeRef} = config;
 

--- a/src/components/ChatWindow.tsx
+++ b/src/components/ChatWindow.tsx
@@ -2,29 +2,9 @@
 
 import {jsx} from 'theme-ui';
 import {motion} from 'framer-motion';
-import ChatWidgetContainer from './ChatWidgetContainer';
-import {CustomerMetadata, Message} from '../api';
+import ChatWidgetContainer, {SharedProps} from './ChatWidgetContainer';
 
-type Props = {
-  title?: string;
-  subtitle?: string;
-  primaryColor?: string;
-  accountId: string;
-  baseUrl?: string;
-  greeting?: string;
-  customer?: CustomerMetadata | null;
-  newMessagePlaceholder?: string;
-  agentAvailableText?: string;
-  agentUnavailableText?: string;
-  showAgentAvailability?: boolean;
-  iframeUrlOverride?: string;
-  requireEmailUpfront?: boolean;
-  customIconUrl?: string;
-  onChatOpened?: () => void;
-  onChatClosed?: () => void;
-  onMessageSent?: (message: Message) => void;
-  onMessageReceived?: (message: Message) => void;
-};
+type Props = SharedProps & {};
 
 const ChatWindow = (props: Props) => {
   // TODO: add a prop to `ChatWidgetContainer` to indicate when component is not

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -5,6 +5,12 @@ export const open = () => window.dispatchEvent(new Event('papercups:open'));
 export const close = () => window.dispatchEvent(new Event('papercups:close'));
 export const toggle = () => window.dispatchEvent(new Event('papercups:toggle'));
 
+export const Papercups = {
+  open,
+  close,
+  toggle,
+};
+
 export {ChatWidget, ChatWindow};
 
 export default ChatWidget;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,3 +1,6 @@
 import ChatWidget from './components/ChatWidget';
+import ChatWindow from './components/ChatWindow';
+
+export {ChatWidget, ChatWindow};
 
 export default ChatWidget;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,6 +1,10 @@
 import ChatWidget from './components/ChatWidget';
 import ChatWindow from './components/ChatWindow';
 
+export const open = () => window.dispatchEvent(new Event('papercups:open'));
+export const close = () => window.dispatchEvent(new Event('papercups:close'));
+export const toggle = () => window.dispatchEvent(new Event('papercups:toggle'));
+
 export {ChatWidget, ChatWindow};
 
 export default ChatWidget;

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -183,6 +183,12 @@ export const getThemeConfig = (settings: ThemeSettings) => {
           },
         },
       },
+      ChatWindowContainer: {
+        margin: 0,
+        height: '100%',
+        width: '100%',
+        minHeight: 320,
+      },
       WidgetContainer: {
         margin: 0,
         zIndex: 2147483000,

--- a/src/track/helpers.ts
+++ b/src/track/helpers.ts
@@ -10,6 +10,7 @@ export const helpers = (win: any) => {
   const windowOpera = (win as any).opera;
   const screen = win.screen;
   const userAgent = navigator.userAgent;
+  const intl = win.Intl;
 
   const nativeBind = FuncProto.bind;
   const nativeForEach = ArrayProto.forEach;
@@ -677,6 +678,7 @@ export const helpers = (win: any) => {
     windowOpera,
     screen,
     userAgent,
+    intl,
     nativeBind,
     nativeForEach,
     nativeIndexOf,

--- a/src/track/info.ts
+++ b/src/track/info.ts
@@ -5,6 +5,7 @@ export function getUserInfo(win: any) {
     navigator,
     userAgent,
     windowOpera,
+    intl,
     each,
     extend,
     includes,
@@ -212,6 +213,14 @@ export function getUserInfo(win: any) {
       return '';
     },
 
+    timezone: function (intl: any) {
+      try {
+        return intl.DateTimeFormat().resolvedOptions().timeZone;
+      } catch (e) {
+        return null;
+      }
+    },
+
     properties: function () {
       return extend(
         stripEmptyProperties({
@@ -220,6 +229,7 @@ export function getUserInfo(win: any) {
           referrer: document.referrer,
           referring_domain: info.referringDomain(document.referrer),
           device: info.device(userAgent),
+          time_zone: info.timezone(intl),
         }),
         {
           current_url: win.location.href,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -12,6 +12,7 @@ export type WidgetConfig = {
   showAgentAvailability?: 1 | 0;
   requireEmailUpfront?: 1 | 0;
   customerId?: string;
+  subscriptionPlan?: string;
   metadata?: string; // stringified JSON
 };
 


### PR DESCRIPTION
_If you want to try this out, install `"@papercups-io/chat-widget": "^1.1.0-beta.5"` and then `import {ChatWindow} from '@papercups-io/chat-widget'`_ 

(React props are the same as the `ChatWidget` component)

TODOs:
- [x] Fix scroll issue affecting parent content
- [x] Add prop to indicate that `ChatWindow` does not have any toggle-able behavior (i.e. disable certain actions in the `ChatWidgetContainer`)

This update will allow users to embed the chat window wherever they want!

Example:
<img width="512" alt="Screen Shot 2020-09-04 at 10 28 16 PM" src="https://user-images.githubusercontent.com/5264279/92296003-f8692b80-eefd-11ea-8b96-10a41f355968.png">

Can style with CSS classes, e.g.
```css
.Papercups-chatWindowContainer {
  border-radius: 4px;
  box-shadow: rgba(0, 0, 0, 0.16) 0px 5px 24px;
}
```