### PR TITLE
Add support for persisting the open/closed state of the chat (`persistOpenState`)

### DIFF
--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -125,13 +125,13 @@ const App = ({disco, displayChatWindow}: Props) => {
             chatContainer: {
               // left: 20,
               // right: 'auto',
-              bottom: 240,
+              bottom: 160,
               maxHeight: 640,
             },
             toggleContainer: {
               // left: 20,
               // right: 'auto',
-              bottom: 160,
+              bottom: 80,
             },
             toggleButton: {},
           }}

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -120,16 +120,18 @@ const App = ({disco, displayChatWindow}: Props) => {
           isOpenByDefault
           iconVariant='filled'
           persistOpenState
-          position={{side: 'left', offset: 80}}
+          position={{side: 'right', offset: 80}}
           styles={{
             chatContainer: {
-              left: 20,
-              right: 'auto',
+              // left: 20,
+              // right: 'auto',
+              bottom: 240,
               maxHeight: 640,
             },
             toggleContainer: {
-              left: 20,
-              right: 'auto',
+              // left: 20,
+              // right: 'auto',
+              bottom: 160,
             },
             toggleButton: {},
           }}

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -117,8 +117,9 @@ const App = ({disco, displayChatWindow}: Props) => {
           requireEmailUpfront
           showAgentAvailability
           hideToggleButton={false}
-          defaultIsOpen={false}
+          isOpenByDefault
           iconVariant='filled'
+          persistOpenState
           styles={{
             chatContainer: {
               // left: 20,

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -120,15 +120,16 @@ const App = ({disco, displayChatWindow}: Props) => {
           isOpenByDefault
           iconVariant='filled'
           persistOpenState
+          position={{side: 'left', offset: 80}}
           styles={{
             chatContainer: {
-              // left: 20,
-              // right: 'auto',
+              left: 20,
+              right: 'auto',
               maxHeight: 640,
             },
             toggleContainer: {
-              // left: 20,
-              // right: 'auto',
+              left: 20,
+              right: 'auto',
             },
             toggleButton: {},
           }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@papercups-io/chat-widget",
-  "version": "1.1.8-beta.0",
+  "version": "1.1.8-beta.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@papercups-io/chat-widget",
-  "version": "1.1.7",
+  "version": "1.1.8-beta.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@papercups-io/chat-widget",
-  "version": "1.1.8-beta.0",
+  "version": "1.1.8-beta.1",
   "description": "Papercups chat widget",
   "author": "reichert621",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@papercups-io/chat-widget",
-  "version": "1.1.7",
+  "version": "1.1.8-beta.0",
   "description": "Papercups chat widget",
   "author": "reichert621",
   "license": "MIT",

--- a/src/api.ts
+++ b/src/api.ts
@@ -36,6 +36,7 @@ export type Account = {
 };
 
 export type WidgetSettings = {
+  id?: string;
   subtitle?: string;
   title?: string;
   base_url?: string;
@@ -44,6 +45,15 @@ export type WidgetSettings = {
   new_message_placeholder?: string;
   email_input_placeholder?: string;
   new_messages_notification_text?: string;
+  is_branding_hidden?: boolean;
+  show_agent_availability?: boolean;
+  agent_available_text?: string;
+  agent_unavailable_text?: string;
+  require_email_upfront?: boolean;
+  is_open_by_default?: boolean;
+  custom_icon_url?: string;
+  iframe_url_override?: string;
+  icon_variant?: 'outlined' | 'filled';
   account?: Account;
 };
 

--- a/src/components/ChatWidget.tsx
+++ b/src/components/ChatWidget.tsx
@@ -24,29 +24,20 @@ type PositionConfig = {
   offset: number;
 };
 
-type Props = SharedProps & {
-  defaultIsOpen?: boolean;
-  isOpenByDefault?: boolean;
-  persistOpenState?: boolean;
-  hideToggleButton?: boolean;
-  iconVariant?: 'outlined' | 'filled';
-  position?: 'left' | 'right' | PositionConfig;
-  renderToggleButton?: (options: ToggleButtonOptions) => React.ReactElement;
-  styles?: StyleOverrides;
-};
+const DEFAULT_X_OFFSET = 20;
 
 const normalizePositionConfig = (
   position?: 'left' | 'right' | PositionConfig
 ): PositionConfig => {
   if (!position) {
-    return {side: 'right', offset: 20};
+    return {side: 'right', offset: DEFAULT_X_OFFSET};
   }
 
   switch (position) {
     case 'left':
-      return {side: 'left', offset: 20};
+      return {side: 'left', offset: DEFAULT_X_OFFSET};
     case 'right':
-      return {side: 'right', offset: 20};
+      return {side: 'right', offset: DEFAULT_X_OFFSET};
     default:
       return position;
   }
@@ -61,7 +52,7 @@ const getDefaultStyles = (
     toggleContainer: toggleContainerStyle = {},
     toggleButton: toggleButtonStyle = {},
   } = styles;
-  const {side = 'right', offset = 20} = position;
+  const {side = 'right', offset = DEFAULT_X_OFFSET} = position;
 
   switch (side) {
     case 'left':
@@ -78,6 +69,17 @@ const getDefaultStyles = (
         toggleButton: toggleButtonStyle,
       };
   }
+};
+
+type Props = SharedProps & {
+  defaultIsOpen?: boolean;
+  isOpenByDefault?: boolean;
+  persistOpenState?: boolean;
+  hideToggleButton?: boolean;
+  iconVariant?: 'outlined' | 'filled';
+  position?: 'left' | 'right' | PositionConfig;
+  renderToggleButton?: (options: ToggleButtonOptions) => React.ReactElement;
+  styles?: StyleOverrides;
 };
 
 const ChatWidget = (props: Props) => {

--- a/src/components/ChatWidget.tsx
+++ b/src/components/ChatWidget.tsx
@@ -13,18 +13,71 @@ type ToggleButtonOptions = {
   onToggleOpen: () => void;
 };
 
+type StyleOverrides = {
+  chatContainer?: CSSProperties;
+  toggleContainer?: CSSProperties;
+  toggleButton?: CSSProperties;
+};
+
+type PositionConfig = {
+  side: 'left' | 'right';
+  offset: number;
+};
+
 type Props = SharedProps & {
   defaultIsOpen?: boolean;
   isOpenByDefault?: boolean;
   persistOpenState?: boolean;
   hideToggleButton?: boolean;
   iconVariant?: 'outlined' | 'filled';
+  position?: 'left' | 'right' | PositionConfig;
   renderToggleButton?: (options: ToggleButtonOptions) => React.ReactElement;
-  styles?: {
-    chatContainer?: CSSProperties;
-    toggleContainer?: CSSProperties;
-    toggleButton?: CSSProperties;
-  };
+  styles?: StyleOverrides;
+};
+
+const normalizePositionConfig = (
+  position?: 'left' | 'right' | PositionConfig
+): PositionConfig => {
+  if (!position) {
+    return {side: 'right', offset: 20};
+  }
+
+  switch (position) {
+    case 'left':
+      return {side: 'left', offset: 20};
+    case 'right':
+      return {side: 'right', offset: 20};
+    default:
+      return position;
+  }
+};
+
+const getDefaultStyles = (
+  styles: StyleOverrides = {},
+  position: PositionConfig
+): StyleOverrides => {
+  const {
+    chatContainer: chatContainerStyle = {},
+    toggleContainer: toggleContainerStyle = {},
+    toggleButton: toggleButtonStyle = {},
+  } = styles;
+  const {side = 'right', offset = 20} = position;
+
+  switch (side) {
+    case 'left':
+      return {
+        chatContainer: {left: offset, right: 'auto', ...chatContainerStyle},
+        toggleContainer: {left: offset, right: 'auto', ...toggleContainerStyle},
+        toggleButton: toggleButtonStyle,
+      };
+    case 'right':
+    default:
+      return {
+        chatContainer: {right: offset, left: 'auto', ...chatContainerStyle},
+        toggleContainer: {right: offset, left: 'auto', ...toggleContainerStyle},
+        toggleButton: toggleButtonStyle,
+      };
+  }
 };
 
 const ChatWidget = (props: Props) => {
@@ -50,13 +103,15 @@ const ChatWidget = (props: Props) => {
             hideToggleButton,
             iconVariant,
             renderToggleButton,
+            position = 'right',
             styles = {},
           } = props;
+          const positionConfig = normalizePositionConfig(position);
           const {
             chatContainer: chatContainerStyle = {},
             toggleContainer: toggleContainerStyle = {},
             toggleButton: toggleButtonStyle = {},
-          } = styles;
+          } = getDefaultStyles(styles, positionConfig);
 
           return (
             <React.Fragment>

--- a/src/components/ChatWidget.tsx
+++ b/src/components/ChatWidget.tsx
@@ -15,6 +15,8 @@ type ToggleButtonOptions = {
 
 type Props = SharedProps & {
   defaultIsOpen?: boolean;
+  isOpenByDefault?: boolean;
+  persistOpenState?: boolean;
   hideToggleButton?: boolean;
   iconVariant?: 'outlined' | 'filled';
   renderToggleButton?: (options: ToggleButtonOptions) => React.ReactElement;

--- a/src/components/ChatWidgetContainer.tsx
+++ b/src/components/ChatWidgetContainer.tsx
@@ -171,8 +171,6 @@ class ChatWidgetContainer extends React.Component<Props, State> {
     const config: WidgetConfig = {
       accountId,
       baseUrl,
-      agentAvailableText,
-      agentUnavailableText,
       title: await this.getDefaultTitle(settings),
       subtitle: await this.getDefaultSubtitle(settings),
       primaryColor: primaryColor || settings.color,
@@ -184,13 +182,19 @@ class ChatWidgetContainer extends React.Component<Props, State> {
       newMessagesNotificationText:
         newMessagesNotificationText || settings.new_messages_notification_text,
       companyName: settings?.account?.company_name,
-      requireEmailUpfront: requireEmailUpfront ? 1 : 0,
-      showAgentAvailability: showAgentAvailability ? 1 : 0,
+      requireEmailUpfront:
+        requireEmailUpfront || settings.require_email_upfront ? 1 : 0,
+      showAgentAvailability:
+        showAgentAvailability || settings.show_agent_availability ? 1 : 0,
+      agentAvailableText: settings.agent_available_text || agentAvailableText,
+      agentUnavailableText:
+        settings.agent_unavailable_text || agentUnavailableText,
       closeable: canToggle ? 1 : 0,
       customerId: this.storage.getCustomerId(),
       subscriptionPlan: settings?.account?.subscription_plan,
+      isBrandingHidden: settings?.is_branding_hidden,
       metadata: JSON.stringify(metadata),
-      version: '1.1.6',
+      version: '1.1.8',
     };
 
     const query = qs.stringify(config, {skipEmptyString: true, skipNull: true});

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -2,59 +2,155 @@
 // TODO: do something different for dev vs prod
 const PREFIX = '__PAPERCUPS__';
 
-// FIXME: this is just a workaround until we can stop
-// relying on localStorage in our chat iframe
-const getStorage = (w: any) => {
-  try {
-    const storage = w && (w.localStorage || w.sessionStorage);
+type StorageType = 'local' | 'session' | 'cookie' | 'memory' | 'none' | null;
 
-    return storage;
-  } catch (e) {
+interface Storage {
+  get: (key: string) => any;
+  set: (key: string, value: any) => void;
+  remove: (key: string) => any;
+}
+
+type FallbackStorage = Storage & {
+  _db: Record<string, any>;
+  getItem: (key: string) => any;
+  setItem: (key: string, value: any) => void;
+  removeItem: (key: string) => any;
+};
+
+const useFallbackStorage = (): FallbackStorage => {
+  return {
+    _db: {},
+    getItem(key: string) {
+      return this._db[key] || null;
+    },
+    setItem(key: string, value: any) {
+      this._db[key] = value;
+    },
+    removeItem(key: string) {
+      delete this._db[key];
+    },
+    // Aliases
+    get(key: string) {
+      return this._db[key] || null;
+    },
+    set(key: string, value: any) {
+      this._db[key] = value;
+    },
+    remove(key: string) {
+      delete this._db[key];
+    },
+  };
+};
+
+const useLocalStorage = (w: any): Storage => {
+  try {
+    const storage = w && w.localStorage;
+
     return {
-      _db: {},
-      getItem(key: string) {
-        return this._db[key] || null;
+      ...storage,
+      get: (key: string) => {
+        const result = storage.getItem(`${PREFIX}${key}`);
+
+        if (!result) {
+          return null;
+        }
+
+        try {
+          return JSON.parse(result);
+        } catch (e) {
+          return result;
+        }
       },
-      setItem(key: string, value: any) {
-        this._db[key] = value;
+      set: (key: string, value: any) => {
+        storage.setItem(`${PREFIX}${key}`, JSON.stringify(value));
       },
-      removeItem(key: string) {
-        delete this._db[key];
+      remove: (key: string) => {
+        storage.removeItem(key);
       },
     };
+  } catch (e) {
+    return useFallbackStorage();
   }
 };
 
-export default function store(w: any) {
-  const storage = getStorage(w);
+const useSessionStorage = (w: any): Storage => {
+  try {
+    const storage = w && w.sessionStorage;
 
-  const get = (key: string) => {
-    const result = storage.getItem(`${PREFIX}${key}`);
+    // NB: this is the same as `localStorage` above
+    return {
+      ...storage,
+      get: (key: string) => {
+        const result = storage.getItem(`${PREFIX}${key}`);
 
-    if (!result) {
-      return null;
+        if (!result) {
+          return null;
+        }
+
+        try {
+          return JSON.parse(result);
+        } catch (e) {
+          return result;
+        }
+      },
+      set: (key: string, value: any) => {
+        storage.setItem(`${PREFIX}${key}`, JSON.stringify(value));
+      },
+      remove: (key: string) => {
+        storage.removeItem(key);
+      },
+    };
+  } catch (e) {
+    return useFallbackStorage();
+  }
+};
+
+const useCookieStorage = (): Storage => {
+  try {
+    throw new Error('Cookie storage has not been implemented!');
+  } catch (e) {
+    return useFallbackStorage();
+  }
+};
+
+// FIXME: this is just a workaround until we can stop
+// relying on localStorage in our chat iframe
+const getPreferredStorage = (w: any, type: StorageType = 'local'): Storage => {
+  try {
+    switch (type) {
+      case 'local':
+        return useLocalStorage(w);
+      case 'session':
+        return useSessionStorage(w);
+      case 'cookie':
+        return useCookieStorage();
+      case 'memory':
+      default:
+        return useFallbackStorage();
     }
+  } catch (e) {
+    return useFallbackStorage();
+  }
+};
 
-    try {
-      return JSON.parse(result);
-    } catch (e) {
-      return result;
-    }
-  };
-
-  const set = (key: string, value: any) => {
-    storage.setItem(`${PREFIX}${key}`, JSON.stringify(value));
-  };
-
-  const remove = (key: string) => {
-    storage.removeItem(key);
-  };
+export default function store(
+  w: any,
+  options: {defaultType?: StorageType; openStateType?: StorageType} = {}
+) {
+  const {defaultType = 'local', openStateType = 'session'} = options;
+  // TODO: add support for using cookies as well
+  const defaultStorage = getPreferredStorage(w, defaultType);
+  const openStateStorage = getPreferredStorage(w, openStateType);
 
   // TODO: improve these names
-
   return {
-    getCustomerId: () => get('__CUSTOMER_ID__'),
-    setCustomerId: (id: string) => set('__CUSTOMER_ID__', id),
-    removeCustomerId: () => remove('__CUSTOMER_ID__'),
+    getCustomerId: () => defaultStorage.get('__CUSTOMER_ID__'),
+    setCustomerId: (id: string) => defaultStorage.set('__CUSTOMER_ID__', id),
+    removeCustomerId: () => defaultStorage.remove('__CUSTOMER_ID__'),
+    // Open state
+    getOpenState: () => openStateStorage.get(':open'),
+    setOpenState: (state: string | boolean) =>
+      openStateStorage.set(':open', state),
+    clearOpenState: () => openStateStorage.remove(':open'),
   };
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -16,6 +16,7 @@ export type WidgetConfig = {
   closeable?: 1 | 0;
   customerId?: string;
   subscriptionPlan?: string;
+  isBrandingHidden?: boolean;
   metadata?: string; // stringified JSON
   version?: string;
 };


### PR DESCRIPTION
- Adds new `persistOpenState` prop to persist the open/closed state of the chat across the session
- Updates `storage` utils to support both localStorage and sessionStorage
- Adds `isOpenByDefault` alias for `defaultIsOpen` (slightly more readable)