### PR TITLE
Add `popUpInitialMessage` prop to enable popping up the initial greeting

### DIFF
--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -119,6 +119,7 @@ const App = ({disco, displayChatWindow}: Props) => {
           showAgentAvailability
           hideOutsideWorkingHours={false}
           hideToggleButton={false}
+          popUpInitialMessage={1000}
           isOpenByDefault
           iconVariant='filled'
           persistOpenState

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -152,5 +152,10 @@ export default function store(
     setOpenState: (state: string | boolean) =>
       openStateStorage.set(':open', state),
     clearOpenState: () => openStateStorage.remove(':open'),
+    // Popup seen state
+    getPopupSeen: () => openStateStorage.get(':pop_up_seen'),
+    setPopupSeen: (state: string | boolean) =>
+      openStateStorage.set(':pop_up_seen', state),
+    clearPopupSeen: () => openStateStorage.remove(':pop_up_seen'),
   };
 }


### PR DESCRIPTION
TODOs:
- [x] Add `popUpInitialMessage` prop to enable popping up the initial greeting
- [x] Test with https://github.com/papercups-io/chat-window/pull/34 more thoroughly
- [ ] Update README with details

![pop-up-message](https://user-images.githubusercontent.com/5264279/113616419-0c574600-9623-11eb-82b8-82f2e97d7ba1.gif)
