### PR TITLE
Include react 17 in peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "deploy": "gh-pages -d example/build"
   },
   "peerDependencies": {
-    "react": "^16.0.0"
+    "react": "^16.0.0 || ^17.0.0"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^4.2.4",


### PR DESCRIPTION
Tested with a project which is using React 17 and it's working fine.