### PR TITLE
Add convenient aria label to WidgetToggle for improve accessibility

### DIFF
--- a/src/components/WidgetToggle.tsx
+++ b/src/components/WidgetToggle.tsx
@@ -159,6 +159,7 @@ export const WidgetToggle = ({
       }}
       disabled={isDisabled}
       onClick={toggle}
+      aria-label={`${isOpen ? 'Close' : 'Open'} chat widget`}
     >
       <ToggleIcon
         customIconUrl={customIconUrl}


### PR DESCRIPTION
### Description
Added aria-label attribute to WidgetToggle so that assistive technologies can correctly articulate what this component is doing

### Test
It is necessary to launch any assistive technologies and use the keyboard or mouse to focus on the component and then the aria-label of this component will be announced